### PR TITLE
Fix git clone instructions - typo in repo name

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Mac OSX installation and build [tips](doc/build-mac.md).
 Cloning the repository:
 
 ```
-$ git clone https://github.com/openliberty/openliberty-s2i
-$ cd openliberty-s2i
+$ git clone https://github.com/openliberty/open-liberty-s2i
+$ cd open-liberty-s2i
 ```
 
 Building the Open Liberty S2I builder:

--- a/doc/build-mac.md
+++ b/doc/build-mac.md
@@ -29,5 +29,5 @@ For example, to build the builder image:
 ```
 $ cekit build docker
 $ cd target/image
-$ docker build -t openliberty/openliberty-s2i:latest .
+$ docker build -t openliberty/open-liberty-s2i:latest .
 ```


### PR DESCRIPTION
typo in repo name