### PR TITLE
Improve recognition of f8 build

### DIFF
--- a/modules/ol-s2i/artifacts/usr/local/s2i/assemble
+++ b/modules/ol-s2i/artifacts/usr/local/s2i/assemble
@@ -66,7 +66,7 @@ if [ -f "$LOCAL_SOURCE_DIR/pom.xml" ]; then
 fi
 
 
-if [ -f "${LOCAL_SOURCE_DIR}/Dockerfile" ]; then
+if [ -f "${LOCAL_SOURCE_DIR}/Dockerfile" ] && [ -d "${LOCAL_SOURCE_DIR}/maven"]; then
  # This is an S2I binary build coming from fabric8-maven-plugin
   echo "S2I binary build from fabric8-maven-plugin detected"
   LOCAL_SOURCE_DIR=$LOCAL_SOURCE_DIR/maven

--- a/test/test-app/Dockerfile
+++ b/test/test-app/Dockerfile
@@ -1,0 +1,2 @@
+This file only exists to make sure that we don't incorrectly interpret this app as a fabric8 maven plugin deploy
+


### PR DESCRIPTION
PR for #1 

In addition to checking for the presence of a Dockerfile, look for a directory named "maven" in the root. Unfortunately there isn't much else that lets us distinguish between fabric8 builds and normal s2i builds. 

Also adds a fake Dockerfile to one of the tests so that we know the check works. 