### PR TITLE
Move to official liberty UBI images and update to 20.0.0.3

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -2,8 +2,8 @@ schema_version: 1
 
 name: openliberty/open-liberty-s2i
 version: 1.0
-from: bhdaniel/ol-javaee8-ubi-jdk:19.0.0.12
-description: "Open Liberty UBI image with javaee-8"
+from: openliberty/open-liberty:20.0.0.3-full-java8-openj9-ubi
+description: "Open Liberty UBI image with OpenJDK8"
 labels:
     - name: io.k8s.description
       value: "Open Liberty S2I Image"


### PR DESCRIPTION
Upgrade to version 20.0.0.3. 

Open Liberty is now publishing UBI based docker images with a JDK, so we should be using those. That means we will be using standard UBI instead of minimal. 