### PR TITLE
Update imagestream to use latest tag

### DIFF
--- a/imagestreams/openliberty-ubi-min.json
+++ b/imagestreams/openliberty-ubi-min.json
@@ -21,12 +21,12 @@
         },
         "from": {
           "kind": "DockerImage",
-          "name": "docker.io/openliberty/open-liberty-s2i:19.0.0.9"
+          "name": "docker.io/openliberty/open-liberty-s2i:latest"
         },
         "referencePolicy": {
           "type": "Local"
         },
-        "name": "19.0.0.6"
+        "name": "latest"
       }
     ]
   }


### PR DESCRIPTION
We now have a `latest` tag for s2i images. The default imagestream should use latest rather than specifying a version. 

#9 