### PR TITLE
Update imagestreams

### DIFF
--- a/imagestreams/openliberty-ubi-min.json
+++ b/imagestreams/openliberty-ubi-min.json
@@ -1,5 +1,5 @@
 {
-  "apiVersion": "v1",
+  "apiVersion": "image.openshift.io/v1",
   "kind": "ImageStream",
   "metadata": {
     "annotations": {

--- a/imagestreams/openliberty-ubi-min.json
+++ b/imagestreams/openliberty-ubi-min.json
@@ -11,9 +11,9 @@
     "tags": [
       {
         "annotations": {
-          "description": "Build and run Open Liberty applications on Red Hat Universal Base Image 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/OpenLiberty/open-liberty-s2i/blob/master/README.md.",
+          "description": "Build and run Open Liberty applications on Red Hat Universal Base Image 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/OpenLiberty/open-liberty-s2i/blob/main/README.md.",
           "iconClass": "icon-openliberty",
-          "openshift.io/display-name": "Open Liberty (Latest)",
+          "openshift.io/display-name": "Open Liberty 22.0.0.4 with Java 8",
           "openshift.io/provider-display-name": "IBM",
           "sampleRepo": "https://github.com/openshift/openshift-jee-sample.git",
           "supports": "jee,java",
@@ -21,12 +21,31 @@
         },
         "from": {
           "kind": "DockerImage",
-          "name": "docker.io/openliberty/open-liberty-s2i:latest"
+          "name": "docker.io/openliberty/open-liberty-s2i:22.0.0.4-java8"
         },
         "referencePolicy": {
           "type": "Local"
         },
-        "name": "latest"
+        "name": "22.0.0.4-java8"
+      },
+      {
+        "annotations": {
+          "description": "Build and run Open Liberty applications on Red Hat Universal Base Image 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/OpenLiberty/open-liberty-s2i/blob/main/README.md.",
+          "iconClass": "icon-openliberty",
+          "openshift.io/display-name": "Open Liberty 22.0.0.4 with Java 11",
+          "openshift.io/provider-display-name": "IBM",
+          "sampleRepo": "https://github.com/openshift/openshift-jee-sample.git",
+          "supports": "jee,java",
+          "tags": "builder,openliberty,java"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "docker.io/openliberty/open-liberty-s2i:22.0.0.4-java11"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        },
+        "name": "22.0.0.4-java11"
       }
     ]
   }


### PR DESCRIPTION
- Fix non-groupified non-core APIs
- Update imagestreams to 22.0.0.4 with java8 and java11 variants

The `latest` floating tag has not been updated for some time, so this (based on the current state) updates the imagestream to the latest available version.

Perhaps instead, if new floating tags (e.g. `java8` and `java11`) were to be available in the image, that would certainly simplify maintenance of the imagestream, and I would be happy to adjust this accordingly.
